### PR TITLE
reuse leaderboards from model

### DIFF
--- a/leaderboards/models.py
+++ b/leaderboards/models.py
@@ -75,7 +75,7 @@ leaderboard_classes = [
 from rest_framework import serializers
 
 model_classes = {}
-
+#TODO:use one table and reorganize and/or take a deeper look at schema
 for class_name in leaderboard_classes:
     table_name = class_name.lower()
     meta_class = type('Meta', (), {'db_table': table_name})

--- a/leaderboards/templates/leaderboards/base.html
+++ b/leaderboards/templates/leaderboards/base.html
@@ -89,9 +89,9 @@
 <li class="nav-item">
     <span class="nav-link font-weight-bold">Leaderboards</span>
 </li>
-{% for name in leaderboards.items %}
+{% for item in leaderboards %}
     <li class="nav-item">
-        <a class="nav-link" href="{% url 'leaderboards:leaderboard' name.0 %}">{{ name.1 }}</a>
+        <a class="nav-link" href="{% url 'leaderboards:leaderboard' item.url %}">{{ item.leaderboard }}</a>
     </li>
 {% endfor %}
 

--- a/leaderboards/templates/leaderboards/go_touch_grass.html
+++ b/leaderboards/templates/leaderboards/go_touch_grass.html
@@ -9,17 +9,6 @@
   gtag('config', 'G-EQG3BMRF63');
 </script>
 
-{% block sidebar %}
-<li class="nav-item">
-    <span class="nav-link font-weight-bold">Leaderboards</span>
-</li>
-{% for name in leaderboards.items %}
-    <li class="nav-item">
-        <a class="nav-link" href="{% url 'leaderboards:leaderboard' name.0 %}">{{ name.1 }}</a>
-    </li>
-{% endfor %}
-{% endblock %}
-
 {% block content %}
 <h1>{{ leaderboard_name }}</h1>
 <br>

--- a/leaderboards/templates/leaderboards/leaderboard.html
+++ b/leaderboards/templates/leaderboards/leaderboard.html
@@ -8,16 +8,6 @@
     
       gtag('config', 'G-EQG3BMRF63');
     </script>
-{% block sidebar %}
-<li class="nav-item">
-    <span class="nav-link font-weight-bold">Leaderboards</span>
-</li>
-{% for name in leaderboards.items %}
-    <li class="nav-item">
-        <a class="nav-link" href="{% url 'leaderboards:leaderboard' name.0 %}">{{ name.1 }}</a>
-    </li>
-{% endfor %}
-{% endblock %}
 
 {% block content %}
 <h1>{{ leaderboard_name }}</h1>

--- a/leaderboards/templates/leaderboards/player_search.html
+++ b/leaderboards/templates/leaderboards/player_search.html
@@ -1,14 +1,5 @@
 {% extends 'leaderboards/base.html' %}
-{% block sidebar %}
-<li class="nav-item">
-    <span class="nav-link font-weight-bold">Leaderboards</span>
-</li>
-{% for name in leaderboards.items %}
-    <li class="nav-item">
-        <a class="nav-link" href="{% url 'leaderboards:leaderboard' name.0 %}">{{ name.1 }}</a>
-    </li>
-{% endfor %}
-{% endblock %}
+
 {% block content %}
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-EQG3BMRF63"></script>

--- a/leaderboards/utils.py
+++ b/leaderboards/utils.py
@@ -1,0 +1,5 @@
+import re
+
+
+def humanize_leaderboard_name(leaderboard_name):
+    return re.sub(r'(?<!^)([A-Z])', r' \1', leaderboard_name.replace('ExperienceWeapon', '')).title().lower()


### PR DESCRIPTION
removed sidebar in html to use base.html default (didn't think they were different in any of the other html files)

Organized sidebar leaderboards alphabetically by using a sortable list of dictionary instead of a plain dictionary (not sortable)

Added a utils.py to help import functions if need be so we can import them at the top for better code organization