### PR TITLE
Initial creation of cumulative hourly player count.

### DIFF
--- a/chivstats/settings.py
+++ b/chivstats/settings.py
@@ -30,7 +30,7 @@ with open(chivcred_location) as f:
     SECRET_KEY = f.read().strip()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 ALLOWED_HOSTS = ['*']
 if DEBUG:
     import socket

--- a/chivstats/settings.py
+++ b/chivstats/settings.py
@@ -30,7 +30,7 @@ with open(chivcred_location) as f:
     SECRET_KEY = f.read().strip()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 ALLOWED_HOSTS = ['*']
 if DEBUG:
     import socket

--- a/leaderboards/models.py
+++ b/leaderboards/models.py
@@ -7,7 +7,9 @@ class HourlyPlayerCount(models.Model):
     player_count = models.IntegerField()
 
     class Meta:
+        db_table = 'hourly_player_count'
         ordering = ['timestamp_hour']
+
 
 class LatestLeaderboard(models.Model):
     leaderboard_name = models.CharField(max_length=255, primary_key=True)

--- a/leaderboards/models.py
+++ b/leaderboards/models.py
@@ -2,6 +2,13 @@ from django.db import models
 from django.db.models import JSONField
 from rest_framework import serializers
 
+class HourlyPlayerCount(models.Model):
+    timestamp_hour = models.DateTimeField()
+    player_count = models.IntegerField()
+
+    class Meta:
+        ordering = ['timestamp_hour']
+
 class LatestLeaderboard(models.Model):
     leaderboard_name = models.CharField(max_length=255, primary_key=True)
     serialnumber = models.IntegerField()

--- a/leaderboards/templates/leaderboards/base.html
+++ b/leaderboards/templates/leaderboards/base.html
@@ -82,6 +82,9 @@
                         <li class="nav-item">
                             <a class="nav-link" href="{% url 'leaderboards:player_search' %}">Player Search</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{% url 'leaderboards:hourly_player_count' %}">Hourly Player Count</a>
+                        </li>
                         {% block sidebar %}
                         {% for item in leaderboards %}
                         {% if item.category == 'category' %}

--- a/leaderboards/templates/leaderboards/hourly_graph.html
+++ b/leaderboards/templates/leaderboards/hourly_graph.html
@@ -1,0 +1,40 @@
+{% extends "leaderboards/base.html" %}
+
+{% block content %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<canvas id="hourlyPlayerCountGraph" width="400" height="200"></canvas>
+
+<script>
+    fetch('/api/hourly-player-count/')
+        .then(response => response.json())
+        .then(data => {
+            const ctx = document.getElementById('hourlyPlayerCountGraph').getContext('2d');
+            const labels = data.map(entry => new Date(entry.timestamp_hour));
+            const values = data.map(entry => entry.player_count);
+
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: 'Hourly Player Count',
+                        data: values,
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        fill: false
+                    }]
+                },
+                options: {
+                    scales: {
+                        x: {
+                            type: 'time',
+                            time: {
+                                unit: 'hour'
+                            }
+                        }
+                    }
+                }
+            });
+        });
+</script>
+{% endblock %}

--- a/leaderboards/templates/leaderboards/hourly_graph.html
+++ b/leaderboards/templates/leaderboards/hourly_graph.html
@@ -1,24 +1,30 @@
 {% extends "leaderboards/base.html" %}
 
 {% block content %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<!-- Moment.js -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
+
+<!-- Chart.js v2 and its Moment.js adapter -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@0.1.1"></script>
 
 <canvas id="hourlyPlayerCountGraph" width="400" height="200"></canvas>
 
 <script>
-    fetch('/api/hourly-player-count/')
+    fetch('/leaderboards/api/hourly-player-count/')
         .then(response => response.json())
         .then(data => {
             const ctx = document.getElementById('hourlyPlayerCountGraph').getContext('2d');
-            const labels = data.map(entry => new Date(entry.timestamp_hour));
+            const labels = data.map(entry => moment.utc(entry.timestamp_hour).local().format('MMM D, YYYY h:mm A z'));  // Convert UTC to local time and format it
             const values = data.map(entry => entry.player_count);
+            const deltas = values.map((value, index, array) => index === 0 ? 0 : value - array[index - 1]);
 
-            new Chart(ctx, {
+            const chart = new Chart(ctx, {
                 type: 'line',
                 data: {
                     labels: labels,
                     datasets: [{
-                        label: 'Hourly Player Count',
+                        label: 'Cumulative Hourly Player count',
                         data: values,
                         borderColor: 'rgba(75, 192, 192, 1)',
                         fill: false
@@ -29,10 +35,34 @@
                         x: {
                             type: 'time',
                             time: {
-                                unit: 'hour'
-                            }
+                                unit: 'hour',
+                                displayFormats: {
+                                    hour: 'MMM D, YYYY h:mm A z'  // Display time in 12-hour format with human-friendly timezone
+                                },
+                                tooltipFormat: 'MMM D, YYYY h:mm A z'  // Tooltip format
+                            },
+                            distribution: 'linear'
                         }
-                    }
+                    },
+                    animation: {
+    onComplete: function() {
+        const ctx = chart.ctx;
+        ctx.fillStyle = 'black';  // Set text color to black
+        ctx.font = Chart.helpers.fontString(Chart.defaults.global.defaultFontSize, 'bold', Chart.defaults.global.defaultFontFamily);  // Set font to bold
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'bottom';
+
+        chart.data.datasets.forEach(function(dataset, i) {
+            const meta = chart.getDatasetMeta(i);
+            meta.data.forEach(function(bar, index) {
+                const delta = deltas[index];
+                const deltaText = delta >= 0 ? `+${delta}` : `${delta}`;
+                ctx.fillText(deltaText, bar._model.x, bar._model.y - 5);
+            });
+        });
+    }
+}
+
                 }
             });
         });

--- a/leaderboards/urls.py
+++ b/leaderboards/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path('api/latest-leaderboards/', LatestLeaderboardListAPIView.as_view(), name='latest-leaderboards'),
     path('api/leaderboards/', LeaderboardListAPIView.as_view(), name='leaderboards-api'),
     path('api/get_leaderboard/', views.get_leaderboard, name='get_leaderboard'),
-    path('hourly_player_count_page/', views.hourly_player_count_page, name='hourly_player_count_page'),
+    path('hourly_player_count/', views.get_hourly_player_count, name='hourly_player_count'),
+    path('api/hourly-player-count/', views.get_hourly_player_count, name='api_hourly_player_count'),
     path('<str:leaderboard_name>/', views.leaderboard, name='leaderboard'),
 ]

--- a/leaderboards/urls.py
+++ b/leaderboards/urls.py
@@ -2,8 +2,6 @@ from django.urls import path
 from . import views
 from .views import PlayerListAPIView, LatestLeaderboardListAPIView, LeaderboardListAPIView, get_leaderboard
 
-
-
 app_name = 'leaderboards'
 
 urlpatterns = [
@@ -17,7 +15,6 @@ urlpatterns = [
     path('api/latest-leaderboards/', LatestLeaderboardListAPIView.as_view(), name='latest-leaderboards'),
     path('api/leaderboards/', LeaderboardListAPIView.as_view(), name='leaderboards-api'),
     path('api/get_leaderboard/', views.get_leaderboard, name='get_leaderboard'),
+    path('hourly_player_count_page/', views.hourly_player_count_page, name='hourly_player_count_page'),
     path('<str:leaderboard_name>/', views.leaderboard, name='leaderboard'),
-    
-    
 ]

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -7,7 +7,7 @@ from django.apps import apps
 from django.core.paginator import Paginator
 from django.db.models import Avg
 from django.db.models import Max
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.shortcuts import render
 from rest_framework import generics
 from rest_framework.decorators import api_view
@@ -15,7 +15,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from leaderboards import models
-from .models import Leaderboard, Player
+from .models import Leaderboard, Player, HourlyPlayerCount
 # import the leaderboard List since it should be defined just in one place
 from .models import (leaderboard_classes, LatestLeaderboard, ChivstatsSumstats)
 from .serializers import (LatestLeaderboardSerializer, PlayerSerializer)
@@ -27,6 +27,10 @@ leaderboards = copy(leaderboard_classes);
 leaderboards.sort(key=organize_sidebar);
 #list of dicts of url and readable text
 leaderboard_list_of_dict = create_leaderboard_list()
+
+def get_hourly_player_count(request):
+    data = list(HourlyPlayerCount.objects.values('timestamp_hour', 'player_count'))
+    return JsonResponse(data, safe=False)
 
 def tattle(request):
     players = Player.objects.filter(badlist=True)

--- a/leaderboards/views.py
+++ b/leaderboards/views.py
@@ -28,9 +28,16 @@ leaderboards.sort(key=organize_sidebar);
 #list of dicts of url and readable text
 leaderboard_list_of_dict = create_leaderboard_list()
 
+def get_leaderboards_context():
+    return {'leaderboards': leaderboard_list_of_dict}
+
 def get_hourly_player_count(request):
-    data = list(HourlyPlayerCount.objects.values('timestamp_hour', 'player_count'))
-    return JsonResponse(data, safe=False)
+    if request.path.endswith('/api/hourly-player-count/'):
+        data = list(HourlyPlayerCount.objects.values('timestamp_hour', 'player_count'))
+        return JsonResponse(data, safe=False)
+    else:
+        context = get_leaderboards_context()  # Get the leaderboards context
+        return render(request, 'leaderboards/hourly_graph.html', context)
 
 def tattle(request):
     players = Player.objects.filter(badlist=True)


### PR DESCRIPTION
Creates api https://chivstats.xyz/leaderboards/api/hourly-player-count/
Creates page https://chivstats.xyz/leaderboards/hourly_player_count/

Cumulative hourly playercount based on hourly polls of DailyPlaytime.

Database table hourly_player_count looks like this:
```
# select * from hourly_player_count;
   timestamp_hour    | player_count 
---------------------+--------------
 2023-08-25 01:00:00 |        11626
 2023-08-25 02:00:00 |        15435
 2023-08-25 03:00:00 |        20860
 2023-08-25 04:00:00 |        25198
(4 rows)
```